### PR TITLE
94:”摩天大楼“改为”空中阁楼“

### DIFF
--- a/ProperNouns.md
+++ b/ProperNouns.md
@@ -91,7 +91,7 @@
  12. KANAL = 运河
  13. OREGON = 俄勒冈乡间屋宅
  14. PRESIDENTIAL PLANE = 总统专机
- 15. SKYSCRAPER = 摩天大楼
+ 15. SKYSCRAPER = 空中阁楼
  16. THEME PARK = 主题公园
     1. 1F Haunted Stairs = 一楼闹鬼楼梯
  17. TOWER = 塔楼


### PR DESCRIPTION
将”摩天大楼”改为“空中阁楼“，其目的在于许多新玩家无法区分”摩天大楼“和”塔楼“甚至老玩家也有时候会说错。而由地图可知”摩天大楼“是一幢日本风格建筑，但凌驾于高楼之上。而塔楼则类似电视塔一类建筑，故不改动。